### PR TITLE
MODUSERS-551. Move edge-users to app-platform-minimal

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,6 @@ Application descriptor repository for app-edge-locate.  Comprised entirely of ed
 | Module name                 |
 |:----------------------------|
 | `edge-inventory`            |
-| `edge-users`                |
 
 ## UI Modules
 

--- a/app-edge-locate.template.json
+++ b/app-edge-locate.template.json
@@ -17,10 +17,6 @@
     {
       "name": "edge-inventory",
       "version": "latest"
-    },
-    {
-      "name": "edge-users",
-      "version": "latest"
     }
   ],
   "uiModules": []

--- a/application.template.json
+++ b/application.template.json
@@ -20,11 +20,6 @@
             "name": "edge-inventory",
             "version": "latest",
             "preRelease": "only"
-        },
-        {
-            "name": "edge-users",
-            "version": "latest",
-            "preRelease": "only"
         }
     ]
 }


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUSERS-551

Move edge-inventory into app-platform-minimal.
After creating app-inventory application edge-inventory will be moved into app-inventory and this repository app-edge-locate will be deprecated.